### PR TITLE
+ RegistrationAdmin

### DIFF
--- a/hhlevents/apps/hhlregistrations/admin.py
+++ b/hhlevents/apps/hhlregistrations/admin.py
@@ -54,10 +54,18 @@ class EventAdmin(HappeningsEventAdmin):
     date_hierarchy = 'start_date'
     inlines = [CancellationInline]
 
+
+
+
+class RegistrationAdmin(admin.ModelAdmin):
+    search_fields = ['event__title', 'person__first_name', 'person__last_name', 'person__email']
+    list_filter = ['state']
+    list_display = ('person','event', 'state')
+
+
 # Remove the happenings event admin
 admin.site.unregister(HappeningsEvent)
 # And use our own
 admin.site.register(Event, EventAdmin)
 admin.site.register(Person)
-admin.site.register(Registration)
-
+admin.site.register(Registration, RegistrationAdmin)   

--- a/hhlevents/apps/hhlregistrations/models.py
+++ b/hhlevents/apps/hhlregistrations/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django_markdown.models import MarkdownField
 from django_markdown.fields import MarkdownFormField
 from happenings.models import Event as HappeningsEvent
+from django.utils import timezone
 
 class Event(HappeningsEvent):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)

--- a/hhlevents/apps/hhlregistrations/models.py
+++ b/hhlevents/apps/hhlregistrations/models.py
@@ -18,7 +18,24 @@ class Event(HappeningsEvent):
     materials_mandatory = models.BooleanField(default=False)
     hide_join_checkbox = models.BooleanField(default=False)
 
-
+    def getRegistrants(self):
+        return Registration.objects.all().filter(event = self.event).order_by('state', 'registered')
+    
+    def getStatsHTML(self):
+        n_AC = Registration.objects.all().filter(event = self.event).filter(state = 'AC').count()
+        n_CC = Registration.objects.all().filter(event = self.event).filter(state = 'CC').count()
+        n_WL = Registration.objects.all().filter(event = self.event).filter(state = 'WL').count()
+        n_CA = Registration.objects.all().filter(event = self.event).filter(state = 'CA').count()
+        n_WB = Registration.objects.all().filter(event = self.event).filter(state = 'WB').count()
+        return u'Assumed coming (AC): %s<br/>Confirmed coming (CC): %s<br/>Waiting-list (WL): %s<br/>Cancelled (CA): %s<br/>Waiting-list (due to ban) (WB): %s' % (n_AC, n_CC, n_WL, n_CA, n_WB)
+    
+    class Meta:
+        ordering = ["-end_date"]
+        
+    def isPast(self):
+        if timezone.now() > self.end_date:
+            return True
+        return False
 
 class Person(models.Model):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)

--- a/hhlevents/apps/hhlregistrations/templates/hhlregistrations/summary.html
+++ b/hhlevents/apps/hhlregistrations/templates/hhlregistrations/summary.html
@@ -1,0 +1,77 @@
+<!-- huom, tämä on nyt tehty pitkälti suomeksi, voi vaihtaa englanniksikin, jos tuntuu paremmalta -->
+
+
+{% extends "admin/base_site.html" %}
+
+
+{% block extrastyle %}
+<style>
+@media print
+{    
+   .no-print, .no-print *
+   {
+      display: none !important;
+   }
+}
+</style>
+{% endblock %}
+
+{% block title %} {{ object }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+
+{% block content %}
+     
+<h3>{{ object }}</h3>
+{% if object.isPast %}<h4 style="color: grey">Huom, tapahtuma on päättynyt</h4>{% endif %}
+       
+<div style="float:right;" class="no-print">
+  <table>
+     {% for list_item in object_list %}
+     <tr{% if list_item.isPast %} style="color: grey"{% endif %}>
+     <td><a href="./{{ list_item.uuid }}">{{ list_item }}</a></td>
+     <td>{{ list_item.start_date|date:"D d.m.Y H:i" }}</td>
+     <td>{{ list_item.end_date|date:"D d.m.Y H:i" }}</td>
+     <td>{{ list_item.location }}</td>
+     </tr>
+     {% endfor %}
+   </table>
+</div>
+       
+       <!-- Tapahtuman perustiedot -->
+<table>
+   <tr><td>Tapahtuma alkaa</td><td>{{ object.start_date|date:"D d.m.Y H:i" }}</td></tr><!-- tähän saisi jostain ehkä jonkun locale:n mukaisen esitystavan -->
+   <tr><td>Tapahtuma päätty</td><td>{{ object.end_date|date:"D d.m.Y H:i"  }}</td></tr>
+   <tr><td>Sijainti</td><td>{{ object.location }}</td></tr>
+   <tr><td>Suurin osallistujamäärä</td><td>{{ object.max_registrations }}</td></tr>
+   <tr><td>Ilmoittautuminen päättyy</td><td>{{ object.close_registrations|date:"D d.m.Y H:i"  }}</td></tr>
+   <tr><td>Osallistumismaksu</td><td>{{ object.event_cost }}</td></tr>
+   <tr><td>Materiaalimaksu</td><td>{{ object.materials_cost }}</td></tr>
+   <tr><td>Materiaalit pakollisia</td><td>{{ object.materials_mandatory }}</td></tr>
+   <tr><td>Eräpäivä</td><td>{{ object.payment_due|date:"D d.m.Y H:i"  }}</td></tr>
+   <tr><td>Erillinen lomake</td><td>{{ object.gforms_url }}</td></tr>
+</table>
+       
+       
+<h5>Osallistujat</h5>
+<ul>{% for reg in object.getRegistrants %}
+   <li>{{ reg }}</li>{% endfor %}
+</ul>
+<small>{% autoescape off %}{{ object.getStatsHTML }}{% endautoescape %}</small>
+       
+       
+<div class="no-print">
+  <h5>Lähetä sähköpostia kaikille osallistujille (BCC)</h5>
+  <form action="/admin/reg_sum/{{ object.uuid }}" method="POST"><!-- /admin/regsum/ varmaan korvattavissa jollain muuttujalla -->
+      <input type="text" name="subject" value="Viesti tapahtumasta {{ object }}" style="width: 450px"><br>        
+      <textarea name="message" rows="10" cols="60">Viesti</textarea><br>
+      {% csrf_token %}
+      <p>Lähetä kopio viestistä osoitteeseen (CC):</p>
+      <input type="text" name="extra_recipient" value="" style="width: 200px"><br>
+      <p>Vastaukset pyydetään lähettämään osoitteeseen (Reply-To):</p>
+      <input type="text" name="reply_to" value="noreply@example.com" style="width: 200px"><br>
+      <input type="submit" value="Submit">
+   </form>
+</div>
+
+{% endblock content %}
+

--- a/hhlevents/apps/hhlregistrations/urls-admin.py
+++ b/hhlevents/apps/hhlregistrations/urls-admin.py
@@ -1,0 +1,11 @@
+# -*- coding: UTF-8 -*-
+from django.conf import settings
+from django.conf.urls import patterns, include, url
+from django.views.generic import TemplateView
+from .views import Summary
+from django.contrib.auth.decorators import permission_required
+
+urlpatterns = patterns('',
+    url(r'^reg_sum/(?P<slug>[a-zA-Z0-9-]+)$', permission_required('is_staff')(Summary.as_view())),
+    url(r'^reg_sum/$', permission_required('is_staff')(Summary.as_view())),
+)

--- a/hhlevents/apps/hhlregistrations/views.py
+++ b/hhlevents/apps/hhlregistrations/views.py
@@ -116,7 +116,7 @@ class Summary(ListDetailMixin, ListView, DetailView):
            sel_event = Event.objects.get(uuid=self.kwargs['slug'])
            print(self.kwargs['slug'])
        except:
-           sel_event = Event.objects.all()[0] # default event, this could be changed to something more intuitive
+           sel_event = None
        return sel_event
    
    def send_email(self, request, *args, **kwargs):

--- a/hhlevents/urls.py
+++ b/hhlevents/urls.py
@@ -18,7 +18,9 @@ urlpatterns = patterns('',
     url(r'^markdown/', include( 'django_markdown.urls')), # No namespace, the library cannot live with it...
     url(r'^register/', include('hhlregistrations.urls', namespace='registrations')),
 
+    url(r'^admin/', include('hhlregistrations.urls-admin')),
     url(r'^admin/', include(admin.site.urls)),
+    
     url(r'^jsi18n', 'django.views.i18n.javascript_catalog', js_info_dict),
     url(r'^i18n/', include('django.conf.urls.i18n')),
 


### PR DESCRIPTION
Ensimmäinen kokeilu.

RegistrationAdmin-luokka: Registrations-näkymä admin-sivuilla sisältää nyt lisää näkyviä tietoja ja suodattimia.

Uusi admin-sivu: /admin/reg_sum/
Sisältää yhteenvetosivun, jossa voi tarkastella tapahtuman perustietoja, osallistujia ja lähettää kaikille osallistujille sähköpostia. Tod.näk. vaatii https://github.com/jsocol/django-adminplus -laajennoksen, jotta saisi näkymään admin-etusivulla.
